### PR TITLE
Add emoji reaction follow support

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -23,7 +23,7 @@
     },
     "emoji_reaction_follow_prob": {
         "description": "跟随别人贴表情的概率",
-        "hint": "监听到群友贴表情事件时，bot跟随贴同款表情的概率。设为0即关闭，独立于“表情跟随概率”",
+        "hint": "监听到群友贴表情事件时，bot跟随贴同款表情的概率。设为0即关闭",
         "type": "float",
         "slider": {
             "min": 0,

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -30,7 +30,7 @@
             "max": 1,
             "step": 0.001
         },
-        "default": 1.0
+        "default": 0.2
     },
     "judge_provider_id": {
         "description": "判断情感用的LLM提供商",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -21,6 +21,17 @@
         },
         "default": 0.03
     },
+    "emoji_reaction_follow_prob": {
+        "description": "跟随别人贴表情的概率",
+        "hint": "监听到群友贴表情事件时，bot跟随贴同款表情的概率。设为0即关闭，独立于“表情跟随概率”",
+        "type": "float",
+        "slider": {
+            "min": 0,
+            "max": 1,
+            "step": 0.001
+        },
+        "default": 1.0
+    },
     "judge_provider_id": {
         "description": "判断情感用的LLM提供商",
         "type": "string",

--- a/core/config.py
+++ b/core/config.py
@@ -131,9 +131,6 @@ class PluginConfig(ConfigNode):
         self.max_emoji_id = 434
         self.emoji_pool = list(range(self.min_emoji_id, self.max_emoji_id))
 
-        if self.emoji_reaction_follow_prob is None:
-            self.emoji_reaction_follow_prob = 1.0
-
         self.emotion_mapping = self.parse_mapping_list()
         self.emotion_labels: list[str] = list(self.emotion_mapping.keys())
 

--- a/core/config.py
+++ b/core/config.py
@@ -112,6 +112,7 @@ class ConfigNode:
 class PluginConfig(ConfigNode):
     emoji_follow_prob: float
     emoji_like_prob: float
+    emoji_reaction_follow_prob: float
     judge_provider_id: str
     emoji_interval: float
     emotions_mapping_list: list[str]
@@ -129,6 +130,9 @@ class PluginConfig(ConfigNode):
         self.min_emoji_id = 1
         self.max_emoji_id = 434
         self.emoji_pool = list(range(self.min_emoji_id, self.max_emoji_id))
+
+        if self.emoji_reaction_follow_prob is None:
+            self.emoji_reaction_follow_prob = 1.0
 
         self.emotion_mapping = self.parse_mapping_list()
         self.emotion_labels: list[str] = list(self.emotion_mapping.keys())

--- a/main.py
+++ b/main.py
@@ -41,6 +41,30 @@ class EmojiLikePlugin(Star):
 
             await asyncio.sleep(self.cfg.emoji_interval)
 
+    async def _follow_reaction_notice(self, event: AiocqhttpMessageEvent) -> bool:
+        raw = getattr(event.message_obj, "raw_message", None)
+        if not raw or raw.get("post_type") != "notice":
+            return False
+        if raw.get("notice_type") not in ("group_msg_emoji_like", "reaction"):
+            return False
+        if raw.get("is_add") is False:
+            return False
+        if str(raw.get("user_id")) == str(event.get_self_id()):
+            return False
+        if random.random() >= self.cfg.emoji_reaction_follow_prob:
+            return False
+
+        message_id = raw.get("message_id")
+        if not message_id:
+            return False
+
+        for item in raw.get("likes") or []:
+            emoji_id = item.get("emoji_id") if isinstance(item, dict) else None
+            if str(emoji_id).isdigit():
+                await self._emoji_like(event, [int(emoji_id)], message_id=message_id)
+                return True
+        return False
+
     @filter.command("贴表情")
     async def on_command(self, event: AiocqhttpMessageEvent, emojiNum: int = 5):
         """贴表情 <数量>"""
@@ -66,6 +90,10 @@ class EmojiLikePlugin(Star):
     @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE)
     async def on_message(self, event: AiocqhttpMessageEvent):
         """群消息监听"""
+        if await self._follow_reaction_notice(event):
+            event.stop_event()
+            return
+
         if event.is_at_or_wake_command:
             return
 


### PR DESCRIPTION
## Summary
- Add support for following group message emoji-like/reaction notice events.
- Add `emoji_reaction_follow_prob` web config; setting it to 0 disables the feature.
- Ignore bot's own reaction events to avoid loops.

## Tests
- `python -m py_compile main.py core/config.py core/emotion.py`
- Simulated `group_msg_emoji_like` and `reaction` notice handling locally.

## Summary by Sourcery

基于可配置的概率，为群聊消息中以下表情回应通知事件添加支持。

新功能：
- 跟随群聊中的表情回应及回应通知事件，自动在原始消息上添加匹配的表情回应。

增强：
- 引入可配置的 `emoji_reaction_follow_prob` 设置，默认值为 1.0，用于控制跟随回应通知的概率。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for following emoji reaction notice events in group messages based on configurable probability.

New Features:
- Follow group emoji reaction and reaction notice events by automatically adding matching emoji reactions to the original message.

Enhancements:
- Introduce a configurable emoji_reaction_follow_prob setting with a default of 1.0 to control the likelihood of following reaction notices.

</details>