### PR TITLE
feat: 新增跟随群友贴表情反应功能

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -59,5 +59,33 @@
             "step": 0.1
         },
         "default": 0.4
+    },
+    "reaction_follow_enabled": {
+        "description": "是否跟随群友贴表情反应",
+        "hint": "开启后，当群友给某条消息贴表情反应时，Bot 会按概率自动贴上相同的表情",
+        "type": "bool",
+        "default": true
+    },
+    "reaction_follow_prob": {
+        "description": "跟随群友贴表情反应的概率",
+        "hint": "群友给消息贴表情反应时，Bot 跟随贴相同表情的概率。建议不要设太高，避免过于频繁",
+        "type": "float",
+        "slider": {
+            "min": 0,
+            "max": 1,
+            "step": 0.001
+        },
+        "default": 0.3
+    },
+    "reaction_follow_dedupe_seconds": {
+        "description": "表情反应跟随去重时间窗口（秒）",
+        "hint": "同一消息同一表情在该时间窗口内只跟随一次，防止短时间内重复跟随",
+        "type": "float",
+        "slider": {
+            "min": 0,
+            "max": 60,
+            "step": 1
+        },
+        "default": 10
     }
 }

--- a/core/config.py
+++ b/core/config.py
@@ -115,6 +115,9 @@ class PluginConfig(ConfigNode):
     judge_provider_id: str
     emoji_interval: float
     emotions_mapping_list: list[str]
+    reaction_follow_enabled: bool
+    reaction_follow_prob: float
+    reaction_follow_dedupe_seconds: float
 
     _plugin_name = "astrbot_plugin_emoji_like"
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+import time
 
 from astrbot.api import logger
 from astrbot.api.event import filter
@@ -14,11 +15,22 @@ from .core.config import PluginConfig
 from .core.emotion import EmotionJudger
 
 
+def _raw_get(raw, key, default=None):
+    """安全读取 raw_message 中的字段，兼容 dict 和对象两种类型"""
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    try:
+        return raw.get(key, default)
+    except Exception:
+        return getattr(raw, key, default)
+
+
 class EmojiLikePlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
         self.cfg = PluginConfig(config, context)
         self.judger = EmotionJudger(self.cfg)
+        self._followed_reactions: dict[tuple[str, str], float] = {}
 
     async def _emoji_like(
         self,
@@ -95,3 +107,82 @@ class EmojiLikePlugin(Star):
         )
         emoji_ids = self.cfg.get_emoji_ids(emotion, need_count=1)
         await self._emoji_like(event, emoji_ids, message_id=message_id)
+
+    def _recently_followed(self, message_id: str, emoji_id: str, ttl: float = 10.0) -> bool:
+        """检查同一消息同一表情是否在去重时间窗口内已被跟随"""
+        now = time.time()
+        key = (str(message_id), str(emoji_id))
+        last = self._followed_reactions.get(key, 0)
+        if now - last < ttl:
+            return True
+        self._followed_reactions[key] = now
+
+        # 缓存超过 500 条时清理过期条目
+        if len(self._followed_reactions) > 500:
+            self._followed_reactions = {
+                k: v for k, v in self._followed_reactions.items() if now - v < ttl
+            }
+
+        return False
+
+    @filter.event_message_type(filter.EventMessageType.ALL)
+    @filter.platform_adapter_type(filter.PlatformAdapterType.AIOCQHTTP)
+    async def on_group_emoji_reaction(self, event: AiocqhttpMessageEvent):
+        """跟随群友给某条消息贴表情反应"""
+        reaction_follow_enabled = getattr(self.cfg, "reaction_follow_enabled", True)
+        if not reaction_follow_enabled:
+            return
+
+        raw = getattr(event.message_obj, "raw_message", None)
+        if raw is None:
+            return
+
+        if _raw_get(raw, "post_type") != "notice":
+            return
+
+        if _raw_get(raw, "notice_type") != "group_msg_emoji_like":
+            return
+
+        # 只跟随"添加表情"，不跟随取消
+        if _raw_get(raw, "is_add") is False:
+            return
+
+        group_id = _raw_get(raw, "group_id")
+        reactor_id = _raw_get(raw, "user_id")
+        self_id = _raw_get(raw, "self_id")
+        message_id = _raw_get(raw, "message_id")
+        likes = _raw_get(raw, "likes", [])
+
+        # 防止 Bot 自己贴表情后再次触发循环
+        if str(reactor_id) == str(self_id):
+            return
+
+        if not message_id or not likes:
+            return
+
+        # 从 likes 中提取 emoji_id，并过滤去重
+        dedupe_seconds = getattr(self.cfg, "reaction_follow_dedupe_seconds", 10.0)
+        emoji_ids = []
+        for item in likes:
+            try:
+                emoji_id = int(item.get("emoji_id") if isinstance(item, dict) else item)
+                if not self._recently_followed(str(message_id), str(emoji_id), dedupe_seconds):
+                    emoji_ids.append(emoji_id)
+            except Exception:
+                continue
+
+        if not emoji_ids:
+            return
+
+        # 按概率决定是否跟随
+        reaction_follow_prob = getattr(self.cfg, "reaction_follow_prob", 0.3)
+        if random.random() >= reaction_follow_prob:
+            return
+
+        logger.info(
+            f"跟随群友贴表情: group={group_id}, reactor={reactor_id}, "
+            f"message={message_id}, emoji_ids={emoji_ids}"
+        )
+
+        await self._emoji_like(event, emoji_ids, message_id=message_id)
+        event.stop_event()


### PR DESCRIPTION
## 功能说明

新增"跟随群友贴表情反应"功能：当群友给某条消息贴表情反应（emoji reaction）时，Bot 按概率自动在同一条消息上贴相同的表情。

### 与现有功能的区别

| 功能 | 现有 | 新增 |
|---|---|---|
| 消息内容含 QQ 表情时跟随 | `emoji_follow_prob` | — |
| 主动 LLM 情感分析贴表情 | `emoji_like_prob` | — |
| 监听群友贴 reaction 后跟随 | — | `reaction_follow_prob` |

### 技术实现

- 通过 `event.message_obj.raw_message` 监听 NapCat/OneBot 的 `group_msg_emoji_like` notice 事件
- 三层防循环机制：`is_add` 过滤 / `reactor_id == self_id` 过滤 / 去重时间窗口缓存
- 复用现有 `_emoji_like()` 执行逻辑

### 新增配置项

| 配置项 | 类型 | 默认值 | 说明 |
|---|---|---|---|
| `reaction_follow_enabled` | bool | true | 是否启用 |
| `reaction_follow_prob` | float | 0.3 | 跟随概率 |
| `reaction_follow_dedupe_seconds` | float | 10 | 去重时间窗口 |

## 由 Sourcery 提供的总结

新增基于概率的后续表情反应功能，该功能会在同一条消息上模仿群成员的表情反应，同时避免形成循环和重复反应。

新功能：
- 新增对 `group_msg_emoji_like` 通知事件的处理，让机器人可以根据可配置的概率，跟随群成员对消息的表情反应。

增强：
- 添加带有 TTL 的“跟随反应去重缓存”，以防止对同一条消息重复进行表情反应，并统一在字典和对象两种类型中安全访问 `raw_message` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add probabilistic follow-up emoji reaction feature that mirrors group members' reactions on the same message while avoiding loops and duplicates.

New Features:
- Introduce handling of group_msg_emoji_like notice events to let the bot follow group members' emoji reactions on messages based on a configurable probability.

Enhancements:
- Add reaction follow deduplication cache with TTL to prevent repeated reactions on the same message and centralize safe access to raw_message fields across dict and object types.

</details>